### PR TITLE
feat: add rk autocomplete enable/disable shell completion

### DIFF
--- a/docs/plans/tags-command-restructure.md
+++ b/docs/plans/tags-command-restructure.md
@@ -1,0 +1,135 @@
+# Plan: Restructure `rk tags` to Group with Subcommands
+
+## Motivation
+
+The current CLI is flat (`rk tags`, `rk sources`, etc.) with no noun-verb grouping, except for `skill` and `auth` which are already `@main.group()` with subcommands. Converting `tags` to a group:
+
+- Matches the existing `skill`/`auth` pattern.
+- Scales to future tag operations (`tags create`, `tags delete`, `tags rename`).
+- Allows `rk tags list --sort sources-desc` naturally.
+
+## Design
+
+### Before
+
+```
+rk tags --root <path>                    # flat command, alpha sort only
+```
+
+### After
+
+```
+rk tags list [--root <path>] [--sort alpha|sources-asc|sources-desc]
+rk tags                                  # same as `rk tags list` (default subcommand)
+```
+
+The `list` subcommand is **the default** — invoking `rk tags` with no subcommand falls through to `rk tags list`.
+
+### `--sort` option values
+
+| Value | Behavior |
+|-------|----------|
+| `alpha` (default) | Alphabetical by tag slug |
+| `sources-asc` | Ascending by source count |
+| `sources-desc` | Descending by source count |
+| `updated-asc` | Ascending by `last_synthesized` timestamp (oldest first; never-synthesized tags sort first) |
+| `updated-desc` | Descending by `last_synthesized` timestamp (newest first; never-synthesized tags sort last) |
+
+### Output format
+
+No change from current:
+
+```
+  tag-name (N sources) [+/-]
+```
+
+The user can pipe to `head` for limiting (no `--limit` needed if that's the only use case).
+
+## Changes Required
+
+### 1. `src/research_keeper/cli.py` — Replace the flat `tags` command
+
+**Remove** (lines ~800-823):
+
+```python
+@main.command()
+@click.option("--root", type=click.Path(exists=True), default=".")
+def tags(root: str) -> None:
+    """List all tags with source counts."""
+    # ... current implementation
+```
+
+**Add**:
+
+```python
+@main.group(invoke_without_command=True)
+@click.pass_context
+def tags(ctx: click.Context) -> None:
+    """List and manage tags."""
+    if ctx.invoked_subcommand is None:
+        ctx.invoke(tags_list)
+
+
+@tags.command("list")
+@click.option("--root", type=click.Path(exists=True), default=".")
+@click.option(
+    "--sort",
+    type=click.Choice(["alpha", "sources-asc", "sources-desc"]),
+    default="alpha",
+    help="Sort order for tags (default: alpha)",
+)
+def tags_list(root: str, sort: str) -> None:
+    """List all tags with source counts."""
+    try:
+        root_path = Path(root).resolve()
+        from research_keeper.adapters.filesystem.tag_store import FilesystemTagStore
+
+        tag_store = FilesystemTagStore(root_path)
+        tag_list = tag_store.list()
+
+        if not tag_list:
+            click.echo("No tags yet.")
+            return
+
+        # Build rows for sorting flexibility
+        rows: list[tuple[str, int, bool, str | None]] = []
+        for tag_slug in tag_list:
+            source_slugs = tag_store.sources_for_tag(tag_slug)
+            has_synthesis = (tag_store.tag_dir(tag_slug) / "synthesis.md").exists()
+            meta = tag_store.get_meta(tag_slug)
+            last_syn = (meta or {}).get("last_synthesized")
+            rows.append((tag_slug, len(source_slugs), has_synthesis, last_syn))
+
+        if sort == "alpha":
+            rows.sort(key=lambda r: r[0])
+        elif sort == "sources-asc":
+            rows.sort(key=lambda r: (r[1], r[0]))
+        elif sort == "sources-desc":
+            rows.sort(key=lambda r: (-r[1], r[0]))
+        elif sort == "updated-asc":
+            rows.sort(key=lambda r: (r[3] or "", r[0]))
+        elif sort == "updated-desc":
+            rows.sort(key=lambda r: (r[3] or "", r[0]), reverse=True)
+
+        for tag_slug, count, has_synthesis, _last_syn in rows:
+            synth_marker = "+" if has_synthesis else "-"
+            click.echo(f"  {tag_slug} ({count} sources) [{synth_marker}]")
+    except Exception as exc:
+        _handle_error(exc)
+```
+
+### 2. `tests/test_cli_tags.py` — Update tests
+
+- Rename `test_tags_command_empty` → `test_tags_list_empty`
+- Rename `test_tags_command_with_tags` → `test_tags_list_with_tags`
+- Change invocation from `["tags", "--root", ...]` to `["tags", "list", "--root", ...]` in both tests
+- Add a new test: `test_tags_list_sort_by_sources_desc` that creates tags with different source counts and verifies output order
+- Add a new test: `test_tags_list_sort_by_updated_desc` that creates tags with different `last_synthesized` timestamps and verifies output order (newest first)
+- Add a new test: `test_tags_list_sort_by_updated_asc` that verifies ascending order by `last_synthesized`
+- Add a new test: `test_tags_defaults_to_list` that invokes `["tags", "--root", ...]` (no subcommand) and confirms it works the same as explicit `list`
+
+## Not in Scope
+
+- `--limit` / `head` support — the user can pipe to `head` as requested.
+- Other subcommands (`tags create`, `tags delete`, etc.) — future work.
+- `rk list tags` variant — the plan settles on `rk tags list`.

--- a/src/research_keeper/cli.py
+++ b/src/research_keeper/cli.py
@@ -1803,15 +1803,20 @@ SHELL_CONFIGS = {
 def _parse_shells(shell_arg: str) -> list[str]:
     """Parse --shell value into list of shell names. Empty means auto-detect."""
     if shell_arg:
-        raw = [s.strip() for s in shell_arg.split(",")]
+        shells = [s.strip() for s in shell_arg.split(",")]
     else:
         raw_shell = os.environ.get("SHELL", "")
-        raw = [Path(raw_shell).name] if raw_shell else []
-    for s in raw:
+        if not raw_shell:
+            raise click.ClickException(
+                "Cannot detect shell: $SHELL is unset. "
+                "Use --shell to specify one or more shells."
+            )
+        shells = [Path(raw_shell).name]
+    for s in shells:
         if s not in SHELL_CONFIGS:
             supported = ", ".join(sorted(SHELL_CONFIGS))
             raise click.ClickException(f"Unsupported shell: {s}. Supported: {supported}")
-    return raw
+    return shells
 
 
 def _resolve_rc(shell: str) -> Path:
@@ -1820,12 +1825,12 @@ def _resolve_rc(shell: str) -> Path:
     if config is None:
         supported = ", ".join(sorted(SHELL_CONFIGS))
         raise click.ClickException(f"Unsupported shell: {shell}. Supported: {supported}")
-    rc_path = Path(config["rc_file"]).expanduser()
-    rc_path.parent.mkdir(parents=True, exist_ok=True)
+    rc_path = Path(config["rc_file"]).expanduser().resolve()
     return rc_path
 
 
 def _autocomplete_line(shell: str) -> str:
+    """Generate the eval line for a shell's completion."""
     config = SHELL_CONFIGS[shell]
     return f'eval "$(_RK_COMPLETE={config["completion_var"]} rk)"'
 
@@ -1842,11 +1847,12 @@ def _is_enabled(rc_path: Path) -> bool:
 
 def _enable_shell(shell: str) -> None:
     rc_path = _resolve_rc(shell)
+    rc_path.parent.mkdir(parents=True, exist_ok=True)
     if _is_enabled(rc_path):
         return
-    block = f"\n{MARKER_START}\n{_autocomplete_line(shell)}\n{MARKER_END}\n"
+    block = f"{MARKER_START}\n{_autocomplete_line(shell)}\n{MARKER_END}\n"
     with rc_path.open("a") as f:
-        f.write(block)
+        f.write(f"\n{block}" if rc_path.stat().st_size > 0 else block)
     click.echo(f"Enabled rk autocomplete for: {shell}")
     click.echo(f"To activate in this shell, run: source {rc_path}")
 
@@ -1860,14 +1866,14 @@ def _disable_shell(shell: str) -> None:
         return
     lines = content.splitlines(keepends=True)
     new_lines: list[str] = []
-    skip = False
+    depth = 0
     for line in lines:
         if MARKER_START in line:
-            skip = True
-        if not skip:
+            depth += 1
+        if depth == 0:
             new_lines.append(line)
         if MARKER_END in line:
-            skip = False
+            depth -= 1
     rc_path.write_text("".join(new_lines))
 
 

--- a/src/research_keeper/cli.py
+++ b/src/research_keeper/cli.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import hashlib
+import os
 import traceback
 from importlib.metadata import version as _pkg_version
 from pathlib import Path
@@ -1790,6 +1791,107 @@ def install(runtime_slugs: tuple[str, ...], global_install: bool) -> None:
     click.echo(
         f"Installed rk skill for {names} ({count} runtime{'s' if count > 1 else ''})"
     )
+
+
+SHELL_CONFIGS = {
+    "zsh": {"rc_file": "~/.zshrc", "completion_var": "zsh_source"},
+    "bash": {"rc_file": "~/.bashrc", "completion_var": "bash_source"},
+    "fish": {"rc_file": "~/.config/fish/config.fish", "completion_var": "fish_source"},
+}
+
+
+def _parse_shells(shell_arg: str) -> list[str]:
+    """Parse --shell value into list of shell names. Empty means auto-detect."""
+    if shell_arg:
+        raw = [s.strip() for s in shell_arg.split(",")]
+    else:
+        raw_shell = os.environ.get("SHELL", "")
+        raw = [Path(raw_shell).name] if raw_shell else []
+    for s in raw:
+        if s not in SHELL_CONFIGS:
+            supported = ", ".join(sorted(SHELL_CONFIGS))
+            raise click.ClickException(f"Unsupported shell: {s}. Supported: {supported}")
+    return raw
+
+
+def _resolve_rc(shell: str) -> Path:
+    """Return the rc file Path for a shell, expanding ~."""
+    config = SHELL_CONFIGS.get(shell)
+    if config is None:
+        supported = ", ".join(sorted(SHELL_CONFIGS))
+        raise click.ClickException(f"Unsupported shell: {shell}. Supported: {supported}")
+    rc_path = Path(config["rc_file"]).expanduser()
+    rc_path.parent.mkdir(parents=True, exist_ok=True)
+    return rc_path
+
+
+def _autocomplete_line(shell: str) -> str:
+    config = SHELL_CONFIGS[shell]
+    return f'eval "$(_RK_COMPLETE={config["completion_var"]} rk)"'
+
+
+MARKER_START = "# rk autocomplete start"
+MARKER_END = "# rk autocomplete end"
+
+
+def _is_enabled(rc_path: Path) -> bool:
+    if not rc_path.exists():
+        return False
+    return MARKER_START in rc_path.read_text()
+
+
+def _enable_shell(shell: str) -> None:
+    rc_path = _resolve_rc(shell)
+    if _is_enabled(rc_path):
+        return
+    block = f"\n{MARKER_START}\n{_autocomplete_line(shell)}\n{MARKER_END}\n"
+    with rc_path.open("a") as f:
+        f.write(block)
+    click.echo(f"Enabled rk autocomplete for: {shell}")
+    click.echo(f"To activate in this shell, run: source {rc_path}")
+
+
+def _disable_shell(shell: str) -> None:
+    rc_path = _resolve_rc(shell)
+    if not rc_path.exists():
+        return
+    content = rc_path.read_text()
+    if MARKER_START not in content:
+        return
+    lines = content.splitlines(keepends=True)
+    new_lines: list[str] = []
+    skip = False
+    for line in lines:
+        if MARKER_START in line:
+            skip = True
+        if not skip:
+            new_lines.append(line)
+        if MARKER_END in line:
+            skip = False
+    rc_path.write_text("".join(new_lines))
+
+
+@main.group()
+def autocomplete() -> None:
+    """Manage rk shell completion."""
+
+
+@autocomplete.command("enable")
+@click.option("--shell", default="", help="Comma-separated shells (default: auto-detect from $SHELL)")
+def autocomplete_enable(shell: str) -> None:
+    """Install shell completion for rk."""
+    shells = _parse_shells(shell)
+    for s in shells:
+        _enable_shell(s)
+
+
+@autocomplete.command("disable")
+@click.option("--shell", default="", help="Comma-separated shells (default: auto-detect from $SHELL)")
+def autocomplete_disable(shell: str) -> None:
+    """Remove rk shell completion."""
+    shells = _parse_shells(shell)
+    for s in shells:
+        _disable_shell(s)
 
 
 @main.group()

--- a/tests/test_cli_autocomplete.py
+++ b/tests/test_cli_autocomplete.py
@@ -90,3 +90,42 @@ def test_autocomplete_detect_from_shell(runner: CliRunner, home_zsh: Path):
     result = runner.invoke(main, ["autocomplete", "enable"])
     assert result.exit_code == 0, result.output
     assert "_RK_COMPLETE=zsh_source rk" in zshrc.read_text()
+
+
+def test_autocomplete_shell_unset_error(runner: CliRunner):
+    shell = os.environ.pop("SHELL", None)
+    try:
+        result = runner.invoke(main, ["autocomplete", "enable"])
+        assert result.exit_code != 0
+        assert "SHELL" in result.output.upper() or "unset" in result.output.lower()
+    finally:
+        if shell is not None:
+            os.environ["SHELL"] = shell
+
+
+def test_autocomplete_disable_nested_markers(runner: CliRunner, home_zsh: Path):
+    zshrc = home_zsh / ".zshrc"
+    content = (
+        "some content\n"
+        "# rk autocomplete start\n"
+        "eval outer\n"
+        "# rk autocomplete start\n"
+        "eval inner\n"
+        "# rk autocomplete end\n"
+        "# rk autocomplete end\n"
+        "remaining\n"
+    )
+    zshrc.write_text(content)
+    result = runner.invoke(main, ["autocomplete", "disable", "--shell", "zsh"])
+    assert result.exit_code == 0
+    assert "# rk autocomplete start" not in zshrc.read_text()
+    assert "# rk autocomplete end" not in zshrc.read_text()
+    assert "remaining" in zshrc.read_text()
+
+
+def test_autocomplete_disable_no_mkdir(runner: CliRunner, home_zsh: Path):
+    config_dir = home_zsh / ".config" / "fish"
+    assert not config_dir.exists()
+    result = runner.invoke(main, ["autocomplete", "disable", "--shell", "fish"])
+    assert result.exit_code == 0
+    assert not config_dir.exists()

--- a/tests/test_cli_autocomplete.py
+++ b/tests/test_cli_autocomplete.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from research_keeper.cli import main
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def home_zsh(tmp_path: Path):
+    """Set HOME to tmp_path so ~/.zshrc resolves there."""
+    old_home = os.environ.get("HOME")
+    os.environ["HOME"] = str(tmp_path)
+    yield tmp_path
+    if old_home is not None:
+        os.environ["HOME"] = old_home
+
+
+def test_autocomplete_enable(runner: CliRunner, home_zsh: Path):
+    zshrc = home_zsh / ".zshrc"
+    result = runner.invoke(main, ["autocomplete", "enable", "--shell", "zsh"])
+    assert result.exit_code == 0, result.output
+    assert zshrc.exists()
+    content = zshrc.read_text()
+    assert "# rk autocomplete start" in content
+    assert "_RK_COMPLETE=zsh_source rk" in content
+    assert "# rk autocomplete end" in content
+    assert "Enabled rk autocomplete for: zsh" in result.output
+    assert ".zshrc" in result.output
+
+
+def test_autocomplete_enable_idempotent(runner: CliRunner, home_zsh: Path):
+    zshrc = home_zsh / ".zshrc"
+    runner.invoke(main, ["autocomplete", "enable", "--shell", "zsh"])
+    result = runner.invoke(main, ["autocomplete", "enable", "--shell", "zsh"])
+    assert result.exit_code == 0
+    content = zshrc.read_text()
+    assert content.count("# rk autocomplete start") == 1
+
+
+def test_autocomplete_disable(runner: CliRunner, home_zsh: Path):
+    zshrc = home_zsh / ".zshrc"
+    runner.invoke(main, ["autocomplete", "enable", "--shell", "zsh"])
+    result = runner.invoke(main, ["autocomplete", "disable", "--shell", "zsh"])
+    assert result.exit_code == 0
+    assert "# rk autocomplete start" not in zshrc.read_text()
+
+
+def test_autocomplete_disable_idempotent(runner: CliRunner, home_zsh: Path):
+    zshrc = home_zsh / ".zshrc"
+    result = runner.invoke(main, ["autocomplete", "disable", "--shell", "zsh"])
+    assert result.exit_code == 0
+    assert not zshrc.exists() or "# rk autocomplete start" not in zshrc.read_text()
+
+
+def test_autocomplete_multi_shell(runner: CliRunner, home_zsh: Path, tmp_path: Path):
+    zshrc = home_zsh / ".zshrc"
+    bashrc = home_zsh / ".bashrc"
+    fish_dir = home_zsh / ".config" / "fish"
+    fish_dir.mkdir(parents=True)
+    fish_config = fish_dir / "config.fish"
+
+    result = runner.invoke(main, ["autocomplete", "enable", "--shell", "zsh,bash,fish"])
+    assert result.exit_code == 0, result.output
+
+    for rc, expected_shell in [(zshrc, "zsh"), (bashrc, "bash"), (fish_config, "fish")]:
+        assert rc.exists(), f"{rc} not created"
+        content = rc.read_text()
+        assert "# rk autocomplete start" in content, f"start marker missing in {rc}"
+        assert f"_RK_COMPLETE={expected_shell}_source rk" in content, f"completion line missing in {rc}"
+
+
+def test_autocomplete_unknown_shell(runner: CliRunner):
+    result = runner.invoke(main, ["autocomplete", "enable", "--shell", "unknown"])
+    assert result.exit_code != 0
+    assert "unknown" in result.output.lower() or "unsupported" in result.output.lower()
+
+
+def test_autocomplete_detect_from_shell(runner: CliRunner, home_zsh: Path):
+    zshrc = home_zsh / ".zshrc"
+    os.environ["SHELL"] = "/bin/zsh"
+    result = runner.invoke(main, ["autocomplete", "enable"])
+    assert result.exit_code == 0, result.output
+    assert "_RK_COMPLETE=zsh_source rk" in zshrc.read_text()


### PR DESCRIPTION
Add `rk autocomplete enable` and `rk autocomplete disable` commands for zsh, bash, and fish shell completion using Click's built-in completion mechanism.

- `rk autocomplete enable [--shell zsh,bash,fish]` — appends marker block with `_RK_COMPLETE` eval line to rc file
- `rk autocomplete disable [--shell zsh,bash,fish]` — removes marker block
- `--shell` accepts comma-separated list; auto-detects from $SHELL by default
- Both commands are idempotent
- Supported: zsh (`~/.zshrc`), bash (`~/.bashrc`), fish (`~/.config/fish/config.fish`)
- Uses `# rk autocomplete start` / `# rk autocomplete end` marker comments for clean edit