### PR TITLE
feat: restructure rk tags to group with --sort flag

### DIFF
--- a/docs/plans/Completed/tags-command-restructure.md
+++ b/docs/plans/Completed/tags-command-restructure.md
@@ -1,0 +1,135 @@
+# Plan: Restructure `rk tags` to Group with Subcommands
+
+## Motivation
+
+The current CLI is flat (`rk tags`, `rk sources`, etc.) with no noun-verb grouping, except for `skill` and `auth` which are already `@main.group()` with subcommands. Converting `tags` to a group:
+
+- Matches the existing `skill`/`auth` pattern.
+- Scales to future tag operations (`tags create`, `tags delete`, `tags rename`).
+- Allows `rk tags list --sort sources-desc` naturally.
+
+## Design
+
+### Before
+
+```
+rk tags --root <path>                    # flat command, alpha sort only
+```
+
+### After
+
+```
+rk tags list [--root <path>] [--sort alpha|sources-asc|sources-desc]
+rk tags                                  # same as `rk tags list` (default subcommand)
+```
+
+The `list` subcommand is **the default** — invoking `rk tags` with no subcommand falls through to `rk tags list`.
+
+### `--sort` option values
+
+| Value | Behavior |
+|-------|----------|
+| `alpha` (default) | Alphabetical by tag slug |
+| `sources-asc` | Ascending by source count |
+| `sources-desc` | Descending by source count |
+| `updated-asc` | Ascending by `last_synthesized` timestamp (oldest first; never-synthesized tags sort first) |
+| `updated-desc` | Descending by `last_synthesized` timestamp (newest first; never-synthesized tags sort last) |
+
+### Output format
+
+No change from current:
+
+```
+  tag-name (N sources) [+/-]
+```
+
+The user can pipe to `head` for limiting (no `--limit` needed if that's the only use case).
+
+## Changes Required
+
+### 1. `src/research_keeper/cli.py` — Replace the flat `tags` command
+
+**Remove** (lines ~800-823):
+
+```python
+@main.command()
+@click.option("--root", type=click.Path(exists=True), default=".")
+def tags(root: str) -> None:
+    """List all tags with source counts."""
+    # ... current implementation
+```
+
+**Add**:
+
+```python
+@main.group(invoke_without_command=True)
+@click.pass_context
+def tags(ctx: click.Context) -> None:
+    """List and manage tags."""
+    if ctx.invoked_subcommand is None:
+        ctx.invoke(tags_list)
+
+
+@tags.command("list")
+@click.option("--root", type=click.Path(exists=True), default=".")
+@click.option(
+    "--sort",
+    type=click.Choice(["alpha", "sources-asc", "sources-desc"]),
+    default="alpha",
+    help="Sort order for tags (default: alpha)",
+)
+def tags_list(root: str, sort: str) -> None:
+    """List all tags with source counts."""
+    try:
+        root_path = Path(root).resolve()
+        from research_keeper.adapters.filesystem.tag_store import FilesystemTagStore
+
+        tag_store = FilesystemTagStore(root_path)
+        tag_list = tag_store.list()
+
+        if not tag_list:
+            click.echo("No tags yet.")
+            return
+
+        # Build rows for sorting flexibility
+        rows: list[tuple[str, int, bool, str | None]] = []
+        for tag_slug in tag_list:
+            source_slugs = tag_store.sources_for_tag(tag_slug)
+            has_synthesis = (tag_store.tag_dir(tag_slug) / "synthesis.md").exists()
+            meta = tag_store.get_meta(tag_slug)
+            last_syn = (meta or {}).get("last_synthesized")
+            rows.append((tag_slug, len(source_slugs), has_synthesis, last_syn))
+
+        if sort == "alpha":
+            rows.sort(key=lambda r: r[0])
+        elif sort == "sources-asc":
+            rows.sort(key=lambda r: (r[1], r[0]))
+        elif sort == "sources-desc":
+            rows.sort(key=lambda r: (-r[1], r[0]))
+        elif sort == "updated-asc":
+            rows.sort(key=lambda r: (r[3] or "", r[0]))
+        elif sort == "updated-desc":
+            rows.sort(key=lambda r: (r[3] or "", r[0]), reverse=True)
+
+        for tag_slug, count, has_synthesis, _last_syn in rows:
+            synth_marker = "+" if has_synthesis else "-"
+            click.echo(f"  {tag_slug} ({count} sources) [{synth_marker}]")
+    except Exception as exc:
+        _handle_error(exc)
+```
+
+### 2. `tests/test_cli_tags.py` — Update tests
+
+- Rename `test_tags_command_empty` → `test_tags_list_empty`
+- Rename `test_tags_command_with_tags` → `test_tags_list_with_tags`
+- Change invocation from `["tags", "--root", ...]` to `["tags", "list", "--root", ...]` in both tests
+- Add a new test: `test_tags_list_sort_by_sources_desc` that creates tags with different source counts and verifies output order
+- Add a new test: `test_tags_list_sort_by_updated_desc` that creates tags with different `last_synthesized` timestamps and verifies output order (newest first)
+- Add a new test: `test_tags_list_sort_by_updated_asc` that verifies ascending order by `last_synthesized`
+- Add a new test: `test_tags_defaults_to_list` that invokes `["tags", "--root", ...]` (no subcommand) and confirms it works the same as explicit `list`
+
+## Not in Scope
+
+- `--limit` / `head` support — the user can pipe to `head` as requested.
+- Other subcommands (`tags create`, `tags delete`, etc.) — future work.
+- `rk list tags` variant — the plan settles on `rk tags list`.

--- a/docs/plans/autocomplete.md
+++ b/docs/plans/autocomplete.md
@@ -1,0 +1,273 @@
+# `rk autocomplete` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `rk autocomplete enable` and `rk autocomplete disable` for zsh/bash/fish shell completion.
+
+**Architecture:** New `autocomplete` click group as `@main.group()` sibling to `tags`. Uses `Path` for rc file I/O, Click's built-in `_RK_COMPLETE=<shell>_source rk` eval pattern, marker-comment blocks for idempotent enable/disable, and shell auto-detection from `$SHELL` with comma-delimited `--shell` override.
+
+**Tech Stack:** click, pathlib, os.environ
+
+---
+
+### Task 1: Write test file
+
+**Files:**
+- Create: `tests/test_cli_autocomplete.py`
+
+- [ ] **Step 1: Write all tests**
+
+```python
+# tests/test_cli_autocomplete.py
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from research_keeper.cli import main
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def home_zsh(tmp_path: Path):
+    """Set HOME to tmp_path so ~/.zshrc resolves there."""
+    old_home = os.environ.get("HOME")
+    os.environ["HOME"] = str(tmp_path)
+    yield tmp_path
+    if old_home is not None:
+        os.environ["HOME"] = old_home
+
+
+def test_autocomplete_enable(runner: CliRunner, home_zsh: Path):
+    zshrc = home_zsh / ".zshrc"
+    result = runner.invoke(main, ["autocomplete", "enable", "--shell", "zsh"])
+    assert result.exit_code == 0, result.output
+    assert zshrc.exists()
+    content = zshrc.read_text()
+    assert "# rk autocomplete start" in content
+    assert "_RK_COMPLETE=zsh_source rk" in content
+    assert "# rk autocomplete end" in content
+    assert "Enabled rk autocomplete for: zsh" in result.output
+    assert ".zshrc" in result.output
+
+
+def test_autocomplete_enable_idempotent(runner: CliRunner, home_zsh: Path):
+    zshrc = home_zsh / ".zshrc"
+    runner.invoke(main, ["autocomplete", "enable", "--shell", "zsh"])
+    result = runner.invoke(main, ["autocomplete", "enable", "--shell", "zsh"])
+    assert result.exit_code == 0
+    content = zshrc.read_text()
+    assert content.count("# rk autocomplete start") == 1
+
+
+def test_autocomplete_disable(runner: CliRunner, home_zsh: Path):
+    zshrc = home_zsh / ".zshrc"
+    runner.invoke(main, ["autocomplete", "enable", "--shell", "zsh"])
+    result = runner.invoke(main, ["autocomplete", "disable", "--shell", "zsh"])
+    assert result.exit_code == 0
+    assert "# rk autocomplete start" not in zshrc.read_text()
+
+
+def test_autocomplete_disable_idempotent(runner: CliRunner, home_zsh: Path):
+    zshrc = home_zsh / ".zshrc"
+    result = runner.invoke(main, ["autocomplete", "disable", "--shell", "zsh"])
+    assert result.exit_code == 0
+    assert not zshrc.exists() or "# rk autocomplete start" not in zshrc.read_text()
+
+
+def test_autocomplete_multi_shell(runner: CliRunner, home_zsh: Path, tmp_path: Path):
+    zshrc = home_zsh / ".zshrc"
+    bashrc = home_zsh / ".bashrc"
+    fish_dir = home_zsh / ".config" / "fish"
+    fish_dir.mkdir(parents=True)
+    fish_config = fish_dir / "config.fish"
+
+    result = runner.invoke(main, ["autocomplete", "enable", "--shell", "zsh,bash,fish"])
+    assert result.exit_code == 0, result.output
+
+    for rc, expected_shell in [(zshrc, "zsh"), (bashrc, "bash"), (fish_config, "fish")]:
+        assert rc.exists(), f"{rc} not created"
+        content = rc.read_text()
+        assert "# rk autocomplete start" in content, f"start marker missing in {rc}"
+        assert f"_RK_COMPLETE={expected_shell}_source rk" in content, f"completion line missing in {rc}"
+
+
+def test_autocomplete_unknown_shell(runner: CliRunner):
+    result = runner.invoke(main, ["autocomplete", "enable", "--shell", "unknown"])
+    assert result.exit_code != 0
+    assert "unknown" in result.output.lower() or "unsupported" in result.output.lower()
+
+
+def test_autocomplete_detect_from_shell(runner: CliRunner, home_zsh: Path):
+    zshrc = home_zsh / ".zshrc"
+    os.environ["SHELL"] = "/bin/zsh"
+    result = runner.invoke(main, ["autocomplete", "enable"])
+    assert result.exit_code == 0, result.output
+    assert "_RK_COMPLETE=zsh_source rk" in zshrc.read_text()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_cli_autocomplete.py -v`
+Expected: all tests FAIL with exit code 2 (no `autocomplete` group)
+
+---
+
+### Task 2: Implement the `autocomplete` group and helpers
+
+**Files:**
+- Modify: `src/research_keeper/cli.py` (add after the `tags` group, before `rebuild`)
+
+- [ ] **Step 1: Add `autocomplete` click group and subcommands**
+
+Insert after the `tags_list` function (after line ~854) and before the `rebuild` command:
+
+```python
+SHELL_CONFIGS = {
+    "zsh": {"rc_file": "~/.zshrc", "completion_var": "zsh_source"},
+    "bash": {"rc_file": "~/.bashrc", "completion_var": "bash_source"},
+    "fish": {"rc_file": "~/.config/fish/config.fish", "completion_var": "fish_source"},
+}
+
+
+def _resolve_rc(shell: str) -> Path:
+    """Return the rc file Path for a shell, expanding ~."""
+    config = SHELL_CONFIGS.get(shell)
+    if config is None:
+        supported = ", ".join(sorted(SHELL_CONFIGS))
+        raise click.ClickException(f"Unsupported shell: {shell}. Supported: {supported}")
+    rc_path = Path(config["rc_file"]).expanduser()
+    rc_path.parent.mkdir(parents=True, exist_ok=True)
+    return rc_path
+
+
+def _autocomplete_line(shell: str) -> str:
+    config = SHELL_CONFIGS.get(shell)
+    return f'eval "$(_RK_COMPLETE={config["completion_var"]} rk)"'
+
+
+MARKER_START = "# rk autocomplete start"
+MARKER_END = "# rk autocomplete end"
+
+
+def _is_enabled(rc_path: Path) -> bool:
+    if not rc_path.exists():
+        return False
+    return MARKER_START in rc_path.read_text()
+
+
+def _enable_shell(shell: str) -> None:
+    rc_path = _resolve_rc(shell)
+    if _is_enabled(rc_path):
+        return
+    block = f"\n{MARKER_START}\n{_autocomplete_line(shell)}\n{MARKER_END}\n"
+    with rc_path.open("a") as f:
+        f.write(block)
+    click.echo(f"Enabled rk autocomplete for: {shell}")
+    click.echo(f"To activate in this shell, run: source {rc_path}")
+
+
+def _disable_shell(shell: str) -> None:
+    rc_path = _resolve_rc(shell)
+    if not rc_path.exists():
+        return
+    content = rc_path.read_text()
+    if MARKER_START not in content:
+        return
+    lines = content.splitlines(keepends=True)
+    new_lines: list[str] = []
+    skip = False
+    for line in lines:
+        if MARKER_START in line:
+            skip = True
+        if not skip:
+            new_lines.append(line)
+        if MARKER_END in line:
+            skip = False
+    rc_path.write_text("".join(new_lines))
+
+
+@main.group()
+def autocomplete() -> None:
+    """Manage rk shell completion."""
+
+
+@autocomplete.command("enable")
+@click.option("--shell", default="", help="Comma-separated shells (default: auto-detect from $SHELL)")
+def autocomplete_enable(shell: str) -> None:
+    """Install shell completion for rk."""
+    shells = _parse_shells(shell)
+    for s in shells:
+        _enable_shell(s)
+
+
+@autocomplete.command("disable")
+@click.option("--shell", default="", help="Comma-separated shells (default: auto-detect from $SHELL)")
+def autocomplete_disable(shell: str) -> None:
+    """Remove rk shell completion."""
+    shells = _parse_shells(shell)
+    for s in shells:
+        _disable_shell(s)
+```
+
+- [ ] **Step 2: Add `_parse_shells` helper before `SHELL_CONFIGS`**
+
+```python
+def _parse_shells(shell_arg: str) -> list[str]:
+    """Parse --shell value into list of shell names. Empty means auto-detect."""
+    if shell_arg:
+        raw = [s.strip() for s in shell_arg.split(",")]
+    else:
+        raw_shell = os.environ.get("SHELL", "")
+        raw = [Path(raw_shell).name] if raw_shell else []
+    for s in raw:
+        if s not in SHELL_CONFIGS:
+            supported = ", ".join(sorted(SHELL_CONFIGS))
+            raise click.ClickException(f"Unsupported shell: {s}. Supported: {supported}")
+    return raw
+```
+
+- [ ] **Step 3: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_cli_autocomplete.py -v`
+Expected: all 7 tests PASS
+
+---
+
+### Task 3: Run full test suite
+
+- [ ] **Step 1: Run tags tests and autocomplete tests together**
+
+Run: `uv run pytest tests/test_cli_tags.py tests/test_cli_autocomplete.py -v`
+Expected: 13 pass (6 tags + 7 autocomplete)
+
+- [ ] **Step 2: Run remaining CLI tests excluding slow rebuild**
+
+Run: `uv run pytest tests/test_cli.py -v -k "not rebuild and not add_multiple_sources" 2>&1 | tail -20`
+Expected: no regressions
+
+---
+
+### Self-review
+
+Going through the spec requirements:
+
+1. `rk autocomplete enable [--shell ...]` — Task 2, `autocomplete_enable`
+2. `rk autocomplete disable [--shell ...]` — Task 2, `autocomplete_disable`
+3. `--shell` comma-delimited, default auto-detect from `$SHELL` — `_parse_shells` in Task 2
+4. Idempotent enable/disable — `_is_enabled` check in `_enable_shell`, early return in `_disable_shell`
+5. Post-modification message with shell name + `source <rc_file>` — `_enable_shell` lines
+6. zsh → `~/.zshrc`, bash → `~/.bashrc`, fish → `~/.config/fish/config.fish` — `SHELL_CONFIGS` dict
+7. rc file markers with `# rk autocomplete start` / `# rk autocomplete end` — `MARKER_START`/`MARKER_END`
+8. Disable removes between markers inclusive — `_disable_shell` lines loop
+9. Unsupported shell → error — validation in `_parse_shells`
+10. Test plan coverage — all 7 spec tests in Task 1
+
+No placeholders. No type inconsistencies.

--- a/docs/plans/tags-command-restructure.md
+++ b/docs/plans/tags-command-restructure.md
@@ -1,0 +1,135 @@
+# Plan: Restructure `rk tags` to Group with Subcommands
+
+## Motivation
+
+The current CLI is flat (`rk tags`, `rk sources`, etc.) with no noun-verb grouping, except for `skill` and `auth` which are already `@main.group()` with subcommands. Converting `tags` to a group:
+
+- Matches the existing `skill`/`auth` pattern.
+- Scales to future tag operations (`tags create`, `tags delete`, `tags rename`).
+- Allows `rk tags list --sort sources-desc` naturally.
+
+## Design
+
+### Before
+
+```
+rk tags --root <path>                    # flat command, alpha sort only
+```
+
+### After
+
+```
+rk tags list [--root <path>] [--sort alpha|sources-asc|sources-desc]
+rk tags                                  # same as `rk tags list` (default subcommand)
+```
+
+The `list` subcommand is **the default** — invoking `rk tags` with no subcommand falls through to `rk tags list`.
+
+### `--sort` option values
+
+| Value | Behavior |
+|-------|----------|
+| `alpha` (default) | Alphabetical by tag slug |
+| `sources-asc` | Ascending by source count |
+| `sources-desc` | Descending by source count |
+| `updated-asc` | Ascending by `last_synthesized` timestamp (oldest first; never-synthesized tags sort first) |
+| `updated-desc` | Descending by `last_synthesized` timestamp (newest first; never-synthesized tags sort last) |
+
+### Output format
+
+No change from current:
+
+```
+  tag-name (N sources) [+/-]
+```
+
+The user can pipe to `head` for limiting (no `--limit` needed if that's the only use case).
+
+## Changes Required
+
+### 1. `src/research_keeper/cli.py` — Replace the flat `tags` command
+
+**Remove** (lines ~800-823):
+
+```python
+@main.command()
+@click.option("--root", type=click.Path(exists=True), default=".")
+def tags(root: str) -> None:
+    """List all tags with source counts."""
+    # ... current implementation
+```
+
+**Add**:
+
+```python
+@main.group(invoke_without_command=True)
+@click.pass_context
+def tags(ctx: click.Context) -> None:
+    """List and manage tags."""
+    if ctx.invoked_subcommand is None:
+        ctx.invoke(tags_list)
+
+
+@tags.command("list")
+@click.option("--root", type=click.Path(exists=True), default=".")
+@click.option(
+    "--sort",
+    type=click.Choice(["alpha", "sources-asc", "sources-desc"]),
+    default="alpha",
+    help="Sort order for tags (default: alpha)",
+)
+def tags_list(root: str, sort: str) -> None:
+    """List all tags with source counts."""
+    try:
+        root_path = Path(root).resolve()
+        from research_keeper.adapters.filesystem.tag_store import FilesystemTagStore
+
+        tag_store = FilesystemTagStore(root_path)
+        tag_list = tag_store.list()
+
+        if not tag_list:
+            click.echo("No tags yet.")
+            return
+
+        # Build rows for sorting flexibility
+        rows: list[tuple[str, int, bool, str | None]] = []
+        for tag_slug in tag_list:
+            source_slugs = tag_store.sources_for_tag(tag_slug)
+            has_synthesis = (tag_store.tag_dir(tag_slug) / "synthesis.md").exists()
+            meta = tag_store.get_meta(tag_slug)
+            last_syn = (meta or {}).get("last_synthesized")
+            rows.append((tag_slug, len(source_slugs), has_synthesis, last_syn))
+
+        if sort == "alpha":
+            rows.sort(key=lambda r: r[0])
+        elif sort == "sources-asc":
+            rows.sort(key=lambda r: (r[1], r[0]))
+        elif sort == "sources-desc":
+            rows.sort(key=lambda r: (-r[1], r[0]))
+        elif sort == "updated-asc":
+            rows.sort(key=lambda r: (r[3] or "", r[0]))
+        elif sort == "updated-desc":
+            rows.sort(key=lambda r: (r[3] or "", r[0]), reverse=True)
+
+        for tag_slug, count, has_synthesis, _last_syn in rows:
+            synth_marker = "+" if has_synthesis else "-"
+            click.echo(f"  {tag_slug} ({count} sources) [{synth_marker}]")
+    except Exception as exc:
+        _handle_error(exc)
+```
+
+### 2. `tests/test_cli_tags.py` — Update tests
+
+- Rename `test_tags_command_empty` → `test_tags_list_empty`
+- Rename `test_tags_command_with_tags` → `test_tags_list_with_tags`
+- Change invocation from `["tags", "--root", ...]` to `["tags", "list", "--root", ...]` in both tests
+- Add a new test: `test_tags_list_sort_by_sources_desc` that creates tags with different source counts and verifies output order
+- Add a new test: `test_tags_list_sort_by_updated_desc` that creates tags with different `last_synthesized` timestamps and verifies output order (newest first)
+- Add a new test: `test_tags_list_sort_by_updated_asc` that verifies ascending order by `last_synthesized`
+- Add a new test: `test_tags_defaults_to_list` that invokes `["tags", "--root", ...]` (no subcommand) and confirms it works the same as explicit `list`
+
+## Not in Scope
+
+- `--limit` / `head` support — the user can pipe to `head` as requested.
+- Other subcommands (`tags create`, `tags delete`, etc.) — future work.
+- `rk list tags` variant — the plan settles on `rk tags list`.

--- a/src/research_keeper/cli.py
+++ b/src/research_keeper/cli.py
@@ -802,6 +802,8 @@ def _count_investigation_links(root_path: Path, slug: str) -> int:
 @click.pass_context
 def tags(ctx: click.Context, root: str) -> None:
     """List and manage tags."""
+    ctx.ensure_object(dict)
+    ctx.obj["root"] = root
     if ctx.invoked_subcommand is None:
         ctx.invoke(tags_list, root=root)
 
@@ -814,10 +816,14 @@ def tags(ctx: click.Context, root: str) -> None:
     default="alpha",
     help="Sort order for tags (default: alpha)",
 )
-def tags_list(root: str, sort: str) -> None:
+@click.pass_context
+def tags_list(ctx: click.Context, root: str, sort: str) -> None:
     """List all tags with source counts."""
     try:
-        root_path = Path(root).resolve()
+        effective_root = root
+        if root == "." and ctx.parent and ctx.parent.obj:
+            effective_root = ctx.parent.obj.get("root", root)
+        root_path = Path(effective_root).resolve()
 
         from research_keeper.adapters.filesystem.tag_store import FilesystemTagStore
 
@@ -843,9 +849,10 @@ def tags_list(root: str, sort: str) -> None:
         elif sort == "sources-desc":
             rows.sort(key=lambda r: (-r[1], r[0]))
         elif sort == "updated-asc":
-            rows.sort(key=lambda r: (r[3] or "", r[0]))
+            rows.sort(key=lambda r: (r[3] if r[3] is not None else "", r[0]))
         elif sort == "updated-desc":
-            rows.sort(key=lambda r: (r[3] or "", r[0]), reverse=True)
+            rows.sort(key=lambda r: r[0])
+            rows.sort(key=lambda r: r[3] if r[3] is not None else "", reverse=True)
 
         for tag_slug, count, has_synthesis, _last_syn in rows:
             synth_marker = "+" if has_synthesis else "-"

--- a/src/research_keeper/cli.py
+++ b/src/research_keeper/cli.py
@@ -797,9 +797,24 @@ def _count_investigation_links(root_path: Path, slug: str) -> int:
     return count
 
 
-@main.command()
+@main.group(invoke_without_command=True)
 @click.option("--root", type=click.Path(exists=True), default=".")
-def tags(root: str) -> None:
+@click.pass_context
+def tags(ctx: click.Context, root: str) -> None:
+    """List and manage tags."""
+    if ctx.invoked_subcommand is None:
+        ctx.invoke(tags_list, root=root)
+
+
+@tags.command("list")
+@click.option("--root", type=click.Path(exists=True), default=".")
+@click.option(
+    "--sort",
+    type=click.Choice(["alpha", "sources-asc", "sources-desc", "updated-asc", "updated-desc"]),
+    default="alpha",
+    help="Sort order for tags (default: alpha)",
+)
+def tags_list(root: str, sort: str) -> None:
     """List all tags with source counts."""
     try:
         root_path = Path(root).resolve()
@@ -813,12 +828,28 @@ def tags(root: str) -> None:
             click.echo("No tags yet.")
             return
 
+        rows: list[tuple[str, int, bool, str | None]] = []
         for tag_slug in tag_list:
             source_slugs = tag_store.sources_for_tag(tag_slug)
-            meta = tag_store.get_meta(tag_slug)
             has_synthesis = (tag_store.tag_dir(tag_slug) / "synthesis.md").exists()
+            meta = tag_store.get_meta(tag_slug)
+            last_syn = (meta or {}).get("last_synthesized")
+            rows.append((tag_slug, len(source_slugs), has_synthesis, last_syn))
+
+        if sort == "alpha":
+            rows.sort(key=lambda r: r[0])
+        elif sort == "sources-asc":
+            rows.sort(key=lambda r: (r[1], r[0]))
+        elif sort == "sources-desc":
+            rows.sort(key=lambda r: (-r[1], r[0]))
+        elif sort == "updated-asc":
+            rows.sort(key=lambda r: (r[3] or "", r[0]))
+        elif sort == "updated-desc":
+            rows.sort(key=lambda r: (r[3] or "", r[0]), reverse=True)
+
+        for tag_slug, count, has_synthesis, _last_syn in rows:
             synth_marker = "+" if has_synthesis else "-"
-            click.echo(f"  {tag_slug} ({len(source_slugs)} sources) [{synth_marker}]")
+            click.echo(f"  {tag_slug} ({count} sources) [{synth_marker}]")
     except Exception as exc:
         _handle_error(exc)
 

--- a/tests/test_cli_tags.py
+++ b/tests/test_cli_tags.py
@@ -15,16 +15,16 @@ def runner():
     return CliRunner()
 
 
-def test_tags_command_empty(runner: CliRunner, library_root: Path):
+def test_tags_list_empty(runner: CliRunner, library_root: Path):
     (library_root / "tags").mkdir(exist_ok=True)
     (library_root / "rk.yaml").write_text("data_dir: .\n")
 
-    result = runner.invoke(main, ["tags", "--root", str(library_root)])
+    result = runner.invoke(main, ["tags", "list", "--root", str(library_root)])
     assert result.exit_code == 0
     assert "no tags" in result.output.lower() or "0" in result.output
 
 
-def test_tags_command_with_tags(runner: CliRunner, library_root: Path):
+def test_tags_list_with_tags(runner: CliRunner, library_root: Path):
     (library_root / "rk.yaml").write_text("data_dir: .\n")
     tags_dir = library_root / "tags"
     tags_dir.mkdir(exist_ok=True)
@@ -36,6 +36,92 @@ def test_tags_command_with_tags(runner: CliRunner, library_root: Path):
         (tag_dir / "meta.yaml").write_text(yaml.dump({"slug": tag, "kind": "tag-synthesis"}))
 
     # Add a source symlink to memory
+    (tags_dir / "memory" / "sources" / "paper-a").symlink_to("../../../../library/sources/paper-a")
+
+    result = runner.invoke(main, ["tags", "list", "--root", str(library_root)])
+    assert result.exit_code == 0
+    assert "memory" in result.output
+    assert "agents" in result.output
+
+
+def _setup_tag(runner: CliRunner, library_root: Path, tag_slug: str, source_count: int) -> None:
+    """Helper to create a tag with N source symlinks and optional meta."""
+    tag_dir = library_root / "tags" / tag_slug
+    tag_dir.mkdir(parents=True, exist_ok=True)
+    (tag_dir / "sources").mkdir(exist_ok=True)
+    for i in range(source_count):
+        sym_path = tag_dir / "sources" / f"source-{i}"
+        if not sym_path.exists():
+            sym_path.symlink_to("../../../../library/sources/dummy")
+    (tag_dir / "meta.yaml").write_text(
+        yaml.dump({"slug": tag_slug, "kind": "tag-synthesis", "cited_sources": [f"source-{i}" for i in range(source_count)]})
+    )
+
+
+def test_tags_list_sort_by_sources_desc(runner: CliRunner, library_root: Path):
+    (library_root / "rk.yaml").write_text("data_dir: .\n")
+    (library_root / "tags").mkdir(exist_ok=True)
+
+    _setup_tag(runner, library_root, "z-tag", 5)
+    _setup_tag(runner, library_root, "a-tag", 1)
+
+    result = runner.invoke(main, ["tags", "list", "--root", str(library_root), "--sort", "sources-desc"])
+    assert result.exit_code == 0
+    lines = [l.strip() for l in result.output.strip().splitlines()]
+    assert "z-tag" in lines[0], f"Expected z-tag (5 sources) first, got: {lines}"
+    assert "a-tag" in lines[1], f"Expected a-tag (1 source) second, got: {lines}"
+
+
+def test_tags_list_sort_by_updated_desc(runner: CliRunner, library_root: Path):
+    (library_root / "rk.yaml").write_text("data_dir: .\n")
+    (library_root / "tags").mkdir(exist_ok=True)
+
+    _setup_tag(runner, library_root, "old-tag", 1)
+    _setup_tag(runner, library_root, "new-tag", 1)
+
+    # Set last_synthesized on old-tag to a past date, new-tag to recent
+    old_meta = {"slug": "old-tag", "kind": "tag-synthesis", "last_synthesized": "2024-01-01T00:00:00"}
+    new_meta = {"slug": "new-tag", "kind": "tag-synthesis", "last_synthesized": "2026-01-01T00:00:00"}
+    (library_root / "tags" / "old-tag" / "meta.yaml").write_text(yaml.dump(old_meta))
+    (library_root / "tags" / "new-tag" / "meta.yaml").write_text(yaml.dump(new_meta))
+
+    result = runner.invoke(main, ["tags", "list", "--root", str(library_root), "--sort", "updated-desc"])
+    assert result.exit_code == 0
+    lines = [l.strip() for l in result.output.strip().splitlines()]
+    assert "new-tag" in lines[0], f"Expected new-tag first (newest), got: {lines}"
+    assert "old-tag" in lines[1], f"Expected old-tag second (oldest), got: {lines}"
+
+
+def test_tags_list_sort_by_updated_asc(runner: CliRunner, library_root: Path):
+    (library_root / "rk.yaml").write_text("data_dir: .\n")
+    (library_root / "tags").mkdir(exist_ok=True)
+
+    _setup_tag(runner, library_root, "old-tag", 1)
+    _setup_tag(runner, library_root, "new-tag", 1)
+
+    old_meta = {"slug": "old-tag", "kind": "tag-synthesis", "last_synthesized": "2024-01-01T00:00:00"}
+    new_meta = {"slug": "new-tag", "kind": "tag-synthesis", "last_synthesized": "2026-01-01T00:00:00"}
+    (library_root / "tags" / "old-tag" / "meta.yaml").write_text(yaml.dump(old_meta))
+    (library_root / "tags" / "new-tag" / "meta.yaml").write_text(yaml.dump(new_meta))
+
+    result = runner.invoke(main, ["tags", "list", "--root", str(library_root), "--sort", "updated-asc"])
+    assert result.exit_code == 0
+    lines = [l.strip() for l in result.output.strip().splitlines()]
+    assert "old-tag" in lines[0], f"Expected old-tag first (oldest), got: {lines}"
+    assert "new-tag" in lines[1], f"Expected new-tag second (newest), got: {lines}"
+
+
+def test_tags_defaults_to_list(runner: CliRunner, library_root: Path):
+    (library_root / "rk.yaml").write_text("data_dir: .\n")
+    tags_dir = library_root / "tags"
+    tags_dir.mkdir(exist_ok=True)
+
+    for tag in ["memory", "agents"]:
+        tag_dir = tags_dir / tag
+        tag_dir.mkdir()
+        (tag_dir / "sources").mkdir()
+        (tag_dir / "meta.yaml").write_text(yaml.dump({"slug": tag, "kind": "tag-synthesis"}))
+
     (tags_dir / "memory" / "sources" / "paper-a").symlink_to("../../../../library/sources/paper-a")
 
     result = runner.invoke(main, ["tags", "--root", str(library_root)])


### PR DESCRIPTION
Convert flat `rk tags` to `@main.group()` with `list` subcommand (default). Adds `--sort` option with 5 modes: alpha, sources-asc, sources-desc, updated-asc, updated-desc.