### PR TITLE
feat: video artifact management and binary safety

### DIFF
--- a/docs/musings/video-artifact-management.md
+++ b/docs/musings/video-artifact-management.md
@@ -1,0 +1,70 @@
+# Video Artifact Management & Binary Safety
+
+**Date:** 2026-07-16
+**Issue:** #48
+**Status:** Musing → Plan
+
+## The Problem
+
+`rk add` on a video URL (YouTube, Instagram, TikTok) extracts text and a screenshot but discards the video. The user must download separately with yt-dlp. Meanwhile, rk already stores binaries (screenshots, PDFs, DOCX) in git with no LFS tracking — a latent bloat problem that video makes acute.
+
+## Design Decisions (from parley)
+
+### Video download: opt-out, not opt-in
+- yt-dlp moves from `media` extra to core dependency
+- `rk add` downloads video by default for any URL classified as `media`
+- `--no-video` flag and config-level `video.enabled: false` to disable
+- No size cap — user decides what to keep
+
+### LFS: init-time setup, not afterthought
+- `rk init` installs git-lfs (platform-aware: brew/apt/dnf/winget/choco)
+- Runs `git lfs install` in the new repo
+- Writes `.gitattributes` tracking all binary types:
+  - Documents: `*.pdf`, `*.docx`, `*.pptx`, `*.xlsx`
+  - Images: `*.jpg`, `*.jpeg`, `*.png`, `*.gif`
+  - Video: `*.mp4`, `*.webm`, `*.mkv`, `*.mov`
+  - Audio: `*.mp3`, `*.wav`, `*.m4a`, `*.flac`, `*.ogg`
+- Stages and commits `.gitattributes` as part of the initial commit
+- If LFS install fails: pre-commit hook as safety net
+
+### Pre-commit hook: Python, not shell
+- Written in Python for cross-platform (Windows/Linux/macOS)
+- Checks staged files >100KB against LFS patterns in `.gitattributes`
+- Rejects with clear message if a large binary isn't LFS-tracked
+- Can be bypassed with `git commit --no-verify` (user's choice, repo bloats)
+
+### rk doctor: LFS health check
+- On `rk update`, doctor runs and detects missing LFS config
+- Asks: "LFS not configured. Set it up? [Y/n]"
+- On yes: install + init + .gitattributes + commit
+- Also checks for committed binaries that should be LFS-tracked
+
+### Cross-platform LFS install
+- macOS: `brew install git-lfs`
+- Linux: `apt install git-lfs` / `dnf install git-lfs` / `yum install git-lfs`
+- Windows: `winget install GitHub.GitLFS` → `choco install git-lfs`
+- Fallback: print platform-specific manual install URL
+
+### Manifest changes
+- `video_file: video.mp4` in manifest.yaml when video is downloaded
+- `video_format`, `video_size` optional metadata
+
+## Open Questions (resolved)
+
+- **Cap?** No cap. User decides what to keep.
+- **Safety if LFS fails?** Pre-commit hook catches large binaries.
+- **Existing repos upgrading?** `rk update` → `rk doctor` → one-time setup flow.
+- **Should init commit .gitattributes?** Yes. Full repo standup is rk init's job.
+- **Should doctor autofix?** No. Ask the user yes/no.
+
+## What's Next
+
+Implementation plan covering:
+1. Config: `VideoConfig` with `enabled: true`
+2. CLI: `--no-video` flag on `rk add`
+3. Pipeline: persist video file alongside source.md
+4. Normalizer: return video path in metadata
+5. Init: LFS install + .gitattributes + pre-commit hook
+6. Doctor: LFS health check + fix flow
+7. Dependencies: yt-dlp to core
+8. Tests for all of the above

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,10 +13,11 @@ dependencies = [
     "pyyaml>=6.0",
     "tqdm>=4.67.3",
     "trafilatura>=2.0",
+    "yt-dlp",
 ]
 
 [project.optional-dependencies]
-media = ["yt-dlp", "faster-whisper>=1.0"]
+media = ["faster-whisper>=1.0"]
 documents = [
     "pymupdf>=1.24",
     "pymupdf4llm>=0.0.17",

--- a/src/research_keeper/adapters/normalizers/media.py
+++ b/src/research_keeper/adapters/normalizers/media.py
@@ -591,6 +591,13 @@ class MediaNormalizer:
         if info.get("webpage_url"):
             extracted["url"] = info["webpage_url"]
 
+        # Video download (opt-out via metadata) — runs unconditionally when enabled
+        if metadata.get("download_video", True):
+            video_path, video_tmpdir = _download_youtube_video(url)
+            if video_path:
+                extracted["_video_path"] = video_path
+                extracted["_video_tmpdir"] = video_tmpdir
+
         # Try subtitles first (manual then auto-captions)
         if subtitles:
             content = f"# {extracted['title']}\n\n{subtitles}"
@@ -642,14 +649,6 @@ class MediaNormalizer:
 
         # Nothing worked
         content = f"# {extracted['title']}\n\n(No transcript available)"
-
-        # Video download (opt-out via metadata)
-        if metadata.get("download_video", True):
-            video_path, video_tmpdir = _download_youtube_video(url)
-            if video_path:
-                extracted["_video_path"] = video_path
-                extracted["_video_tmpdir"] = video_tmpdir
-
         return content, extracted, None
 
     def _normalize_instagram(
@@ -671,6 +670,13 @@ class MediaNormalizer:
         if info.get("webpage_url"):
             extracted["url"] = info["webpage_url"]
 
+        # Video download (opt-out via metadata) — runs unconditionally when enabled
+        if metadata.get("download_video", True):
+            video_path, video_tmpdir = _download_youtube_video(url)
+            if video_path:
+                extracted["_video_path"] = video_path
+                extracted["_video_tmpdir"] = video_tmpdir
+
         if subtitles:
             content = f"# {extracted['title']}\n\n{subtitles}"
             return content, extracted, None
@@ -687,10 +693,7 @@ class MediaNormalizer:
 
         # Frame extraction fallback (opt-in only)
         if enable_frame_extraction:
-            # For Instagram, need to use browser cookies
-            video_path, video_tmpdir = _download_youtube_video(
-                url
-            )  # yt-dlp handles IG URLs too
+            video_path, video_tmpdir = _download_youtube_video(url)
             if video_path:
                 try:
                     frames = _extract_frames_from_video(video_path)
@@ -708,16 +711,6 @@ class MediaNormalizer:
                         shutil.rmtree(video_tmpdir, ignore_errors=True)
 
         content = f"# {extracted['title']}\n\n(No transcript available)"
-
-        # Video download (opt-out via metadata)
-        if metadata.get("download_video", True):
-            video_path, video_tmpdir = _download_youtube_video(
-                url
-            )  # yt-dlp handles IG URLs too
-            if video_path:
-                extracted["_video_path"] = video_path
-                extracted["_video_tmpdir"] = video_tmpdir
-
         return content, extracted, None
 
     def _normalize_audio(self, path: Path, metadata: dict) -> tuple[str, dict]:

--- a/src/research_keeper/adapters/normalizers/media.py
+++ b/src/research_keeper/adapters/normalizers/media.py
@@ -642,6 +642,14 @@ class MediaNormalizer:
 
         # Nothing worked
         content = f"# {extracted['title']}\n\n(No transcript available)"
+
+        # Video download (opt-out via metadata)
+        if metadata.get("download_video", True):
+            video_path, video_tmpdir = _download_youtube_video(url)
+            if video_path:
+                extracted["_video_path"] = video_path
+                extracted["_video_tmpdir"] = video_tmpdir
+
         return content, extracted, None
 
     def _normalize_instagram(
@@ -700,6 +708,16 @@ class MediaNormalizer:
                         shutil.rmtree(video_tmpdir, ignore_errors=True)
 
         content = f"# {extracted['title']}\n\n(No transcript available)"
+
+        # Video download (opt-out via metadata)
+        if metadata.get("download_video", True):
+            video_path, video_tmpdir = _download_youtube_video(
+                url
+            )  # yt-dlp handles IG URLs too
+            if video_path:
+                extracted["_video_path"] = video_path
+                extracted["_video_tmpdir"] = video_tmpdir
+
         return content, extracted, None
 
     def _normalize_audio(self, path: Path, metadata: dict) -> tuple[str, dict]:

--- a/src/research_keeper/cli.py
+++ b/src/research_keeper/cli.py
@@ -86,6 +86,9 @@ def init(path: str) -> None:
         "screenshots": {
             "enabled": True,
         },
+        "video": {
+            "enabled": True,
+        },
         "completion": {
             "models": {
                 "heavy": "anthropic/claude-opus-4",
@@ -108,10 +111,30 @@ def init(path: str) -> None:
     (root / ".gitignore").write_text("rk.db\n__pycache__/\n")
 
     # Init git if not already a repo
-    if not (root / ".git").exists():
-        import subprocess
+    import subprocess
 
+    if not (root / ".git").exists():
         subprocess.run(["git", "init"], cwd=str(root), capture_output=True)
+
+    # Set up Git LFS for binary file tracking
+    from research_keeper.lfs import setup_lfs
+
+    lfs_results = setup_lfs(root)
+    if lfs_results.get("install") is True and lfs_results.get("init") is True:
+        click.echo("Git LFS configured for binary file tracking.")
+        # Stage and commit .gitattributes
+        subprocess.run(
+            ["git", "add", ".gitattributes"],
+            cwd=str(root),
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "rk: add .gitattributes for Git LFS tracking"],
+            cwd=str(root),
+            capture_output=True,
+        )
+    else:
+        click.echo("Warning: Git LFS setup incomplete. Binary files will not be tracked.", err=True)
 
     from research_keeper.component_installer import install_all_components
 
@@ -165,6 +188,13 @@ def init(path: str) -> None:
     default=None,
     help="Disable screenshot capture for web sources",
 )
+@click.option(
+    "--no-video",
+    "no_video_flag",
+    is_flag=True,
+    default=None,
+    help="Disable video download for media sources",
+)
 def add(
     sources: tuple[str, ...],
     root: str,
@@ -177,6 +207,7 @@ def add(
     slug: str | None,
     screenshot_flag: bool | None = None,
     no_screenshot_flag: bool | None = None,
+    no_video_flag: bool | None = None,
 ) -> None:
     """Add one or more sources to the library.
 
@@ -209,6 +240,10 @@ def add(
     elif no_screenshot_flag:
         screenshot_enabled = False
 
+    download_video: bool | None = None
+    if no_video_flag:
+        download_video = False
+
     try:
         root_path = Path(root).resolve()
         pipeline = _build_pipeline(root_path)
@@ -232,6 +267,8 @@ def add(
                 metadata["origin"] = origin
             if published:
                 metadata["published"] = published
+            if download_video is not None:
+                metadata["download_video"] = download_video
 
             try:
                 source = pipeline.add(
@@ -271,6 +308,8 @@ def add(
                     metadata["origin"] = origin
                 if published:
                     metadata["published"] = published
+                if download_video is not None:
+                    metadata["download_video"] = download_video
                 metadata.update(transport_result.metadata)
 
                 if not origin and "origin" not in metadata:
@@ -1663,6 +1702,50 @@ def doctor(root: str, fix: bool) -> None:
     from research_keeper.doctor import Severity, run_doctor
 
     root_path = Path(root).resolve()
+
+    # LFS health check
+    from research_keeper.lfs import is_lfs_installed, setup_lfs
+
+    lfs_ok = is_lfs_installed()
+    gitattributes_path = root_path / ".gitattributes"
+    has_lfs_patterns = False
+    if gitattributes_path.exists():
+        content = gitattributes_path.read_text()
+        has_lfs_patterns = "filter=lfs" in content
+
+    if not lfs_ok or not has_lfs_patterns:
+        click.echo("  [WARN] lfs_check: Git LFS is not fully configured for binary file tracking.")
+        if not lfs_ok:
+            click.echo("         → Git LFS is not installed.")
+        if not has_lfs_patterns:
+            click.echo("         → .gitattributes missing LFS patterns for binary files.")
+        if fix:
+            import sys
+            if sys.stdin.isatty():
+                if click.confirm("Set up Git LFS for binary file tracking?"):
+                    lfs_results = setup_lfs(root_path)
+                    if lfs_results.get("install") is True and lfs_results.get("init") is True:
+                        import subprocess
+                        subprocess.run(
+                            ["git", "add", ".gitattributes"],
+                            cwd=str(root_path),
+                            capture_output=True,
+                        )
+                        subprocess.run(
+                            ["git", "commit", "-m", "rk: add .gitattributes for Git LFS tracking"],
+                            cwd=str(root_path),
+                            capture_output=True,
+                        )
+                        click.echo("         → Git LFS configured successfully.")
+                    else:
+                        click.echo("         → Git LFS setup failed.", err=True)
+            else:
+                click.echo("         → Run 'rk doctor --fix' interactively to set up Git LFS.")
+        else:
+            click.echo("         → Run 'rk doctor --fix' to set up Git LFS.")
+    else:
+        click.echo("  [INFO] lfs_check: Git LFS is configured for binary file tracking.")
+
     results = run_doctor(root_path, fix=fix)
 
     if not results:

--- a/src/research_keeper/config.py
+++ b/src/research_keeper/config.py
@@ -70,6 +70,11 @@ class ScreenshotsConfig:
 
 
 @dataclass
+class VideoConfig:
+    enabled: bool = True
+
+
+@dataclass
 class CompletionConfig:
     models: dict[str, str] = field(
         default_factory=lambda: {
@@ -104,6 +109,7 @@ class Config:
     embeddings: EmbeddingsConfig = field(default_factory=EmbeddingsConfig)
     qmd: QMDConfig = field(default_factory=QMDConfig)
     screenshots: ScreenshotsConfig = field(default_factory=ScreenshotsConfig)
+    video: VideoConfig = field(default_factory=VideoConfig)
     completion: CompletionConfig = field(default_factory=CompletionConfig)
 
     def resolve_root(self, config_parent: Path) -> Path:
@@ -132,6 +138,7 @@ def load_config(path: Path) -> Config:
         ("embeddings", config.embeddings),
         ("qmd", config.qmd),
         ("screenshots", config.screenshots),
+        ("video", config.video),
         ("completion", config.completion),
     ]:
         if section_name in raw and isinstance(raw[section_name], dict):

--- a/src/research_keeper/lfs.py
+++ b/src/research_keeper/lfs.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+import os
+import platform
+import stat
+import subprocess
+from pathlib import Path
+
+LFS_PATTERNS = [
+    "*.pdf",
+    "*.docx",
+    "*.pptx",
+    "*.xlsx",
+    "*.jpg",
+    "*.jpeg",
+    "*.png",
+    "*.gif",
+    "*.mp4",
+    "*.webm",
+    "*.mkv",
+    "*.mov",
+    "*.mp3",
+    "*.wav",
+    "*.m4a",
+    "*.flac",
+    "*.ogg",
+]
+
+GITATTRIBUTES_HEADER = "# Auto-tracked binary files via Git LFS\n"
+
+
+def is_lfs_installed() -> bool:
+    try:
+        result = subprocess.run(
+            ["git", "lfs", "version"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        return result.returncode == 0
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return False
+
+
+def install_lfs() -> bool:
+    system = platform.system()
+    try:
+        if system == "Darwin":
+            subprocess.run(
+                ["brew", "install", "git-lfs"],
+                capture_output=True,
+                text=True,
+                timeout=120,
+            )
+        elif system == "Linux":
+            import shutil
+
+            if shutil.which("apt"):
+                subprocess.run(
+                    ["apt", "install", "-y", "git-lfs"],
+                    capture_output=True,
+                    text=True,
+                    timeout=120,
+                )
+            elif shutil.which("dnf"):
+                subprocess.run(
+                    ["dnf", "install", "-y", "git-lfs"],
+                    capture_output=True,
+                    text=True,
+                    timeout=120,
+                )
+            else:
+                return False
+        elif system == "Windows":
+            import shutil
+
+            if shutil.which("winget"):
+                subprocess.run(
+                    ["winget", "install", "GitLFS"],
+                    capture_output=True,
+                    text=True,
+                    timeout=120,
+                )
+            elif shutil.which("choco"):
+                subprocess.run(
+                    ["choco", "install", "git-lfs"],
+                    capture_output=True,
+                    text=True,
+                    timeout=120,
+                )
+            else:
+                return False
+        else:
+            return False
+        return is_lfs_installed()
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return False
+
+
+def init_lfs(repo_root: Path) -> bool:
+    try:
+        result = subprocess.run(
+            ["git", "lfs", "install"],
+            cwd=str(repo_root),
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        return result.returncode == 0
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return False
+
+
+def write_gitattributes(repo_root: Path) -> Path:
+    gitattributes_path = repo_root / ".gitattributes"
+    existing = gitattributes_path.read_text() if gitattributes_path.exists() else ""
+    lines = existing.splitlines(keepends=True)
+
+    if GITATTRIBUTES_HEADER not in existing:
+        if existing and not existing.endswith("\n"):
+            lines.append("\n")
+        lines.append(GITATTRIBUTES_HEADER)
+        for pattern in LFS_PATTERNS:
+            lines.append(f"{pattern} filter=lfs diff=lfs merge=lfs -text\n")
+
+    gitattributes_path.write_text("".join(lines))
+    return gitattributes_path
+
+
+PRE_COMMIT_HOOK = """#!/usr/bin/env python3
+\"\"\"Pre-commit hook: reject staged binary files >100KB not tracked by Git LFS.\"\"\"
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def get_lfs_patterns() -> set[str]:
+    gitattributes = Path(".gitattributes")
+    if not gitattributes.exists():
+        return set()
+    patterns: set[str] = set()
+    for line in gitattributes.read_text().splitlines():
+        line = line.strip()
+        if line and not line.startswith("#") and "filter=lfs" in line:
+            pattern = line.split()[0]
+            patterns.add(pattern)
+    return patterns
+
+
+def main() -> int:
+    lfs_patterns = get_lfs_patterns()
+    if not lfs_patterns:
+        return 0
+
+    result = subprocess.run(
+        ["git", "diff", "--cached", "--name-only", "-z"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if result.returncode != 0:
+        return 1
+
+    staged_files = [f for f in result.stdout.split("\\0") if f]
+    errors: list[str] = []
+
+    for filepath in staged_files:
+        path = Path(filepath)
+        if not path.exists():
+            continue
+        matched = any(path.match(p) for p in lfs_patterns)
+        if not matched:
+            continue
+        size = path.stat().st_size
+        if size > 100 * 1024:
+            errors.append(
+                f"{filepath} ({size / 1024:.0f} KB) is not tracked by Git LFS. "
+                f"Add it to .gitattributes or use: git lfs track '{path.name}'"
+            )
+
+    if errors:
+        print("LFS pre-commit check failed:")
+        for err in errors:
+            print(f"  {err}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+"""
+
+
+def write_pre_commit_hook(repo_root: Path) -> Path:
+    hooks_dir = repo_root / ".git" / "hooks"
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+    hook_path = hooks_dir / "pre-commit"
+    hook_path.write_text(PRE_COMMIT_HOOK)
+    hook_path.chmod(hook_path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return hook_path
+
+
+def setup_lfs(repo_root: Path) -> dict[str, bool | str]:
+    results: dict[str, bool | str] = {}
+
+    if not is_lfs_installed():
+        results["install"] = install_lfs()
+    else:
+        results["install"] = True
+
+    results["init"] = init_lfs(repo_root)
+    gitattributes_path = write_gitattributes(repo_root)
+    results["gitattributes"] = str(gitattributes_path)
+    hook_path = write_pre_commit_hook(repo_root)
+    results["pre_commit_hook"] = str(hook_path)
+
+    return results

--- a/src/research_keeper/pipeline.py
+++ b/src/research_keeper/pipeline.py
@@ -165,6 +165,19 @@ class IntakePipeline:
             screenshot_path = self._store.source_dir(source.slug) / "source.jpg"
             screenshot_path.write_bytes(screenshot_bytes)
 
+        # Store video if downloaded by normalizer
+        video_path = extracted_meta.pop("_video_path", None)
+        video_tmpdir = extracted_meta.pop("_video_tmpdir", None)
+        if video_path:
+            import shutil
+            source_dir = self._store.source_dir(source.slug)
+            video_ext = Path(video_path).suffix or ".mp4"
+            video_dest = source_dir / f"video{video_ext}"
+            shutil.copy2(video_path, video_dest)
+            merged["video_file"] = video_dest.name
+            if video_tmpdir:
+                shutil.rmtree(video_tmpdir, ignore_errors=True)
+
         # Index (always -- source is searchable via FTS regardless of embedding)
         self._index.upsert_source(source)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -61,3 +61,28 @@ def test_embeddings_config_from_yaml(tmp_path: Path):
     config = load_config(tmp_path / "rk.yaml")
     assert config.embeddings.batch_size == 32
     assert config.embeddings.model == "custom-model"
+
+
+def test_video_config_defaults():
+    from research_keeper.config import VideoConfig
+
+    cfg = VideoConfig()
+    assert cfg.enabled is True
+
+
+def test_video_config_in_config():
+    from research_keeper.config import Config
+
+    c = Config()
+    assert c.video.enabled is True
+
+
+def test_video_config_from_yaml(tmp_path: Path):
+    import yaml
+    from research_keeper.config import load_config
+
+    (tmp_path / "rk.yaml").write_text(
+        yaml.dump({"video": {"enabled": False}})
+    )
+    config = load_config(tmp_path / "rk.yaml")
+    assert config.video.enabled is False

--- a/tests/test_lfs.py
+++ b/tests/test_lfs.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+
+from research_keeper.lfs import (
+    LFS_PATTERNS,
+    GITATTRIBUTES_HEADER,
+    write_gitattributes,
+    write_pre_commit_hook,
+)
+
+
+def test_lfs_patterns_contains_expected():
+    assert "*.pdf" in LFS_PATTERNS
+    assert "*.mp4" in LFS_PATTERNS
+    assert "*.jpg" in LFS_PATTERNS
+    assert "*.png" in LFS_PATTERNS
+    assert "*.docx" in LFS_PATTERNS
+    assert "*.pptx" in LFS_PATTERNS
+    assert "*.xlsx" in LFS_PATTERNS
+    assert "*.gif" in LFS_PATTERNS
+    assert "*.webm" in LFS_PATTERNS
+    assert "*.mkv" in LFS_PATTERNS
+    assert "*.mov" in LFS_PATTERNS
+    assert "*.mp3" in LFS_PATTERNS
+    assert "*.wav" in LFS_PATTERNS
+    assert "*.m4a" in LFS_PATTERNS
+    assert "*.flac" in LFS_PATTERNS
+    assert "*.ogg" in LFS_PATTERNS
+    assert "*.jpeg" in LFS_PATTERNS
+
+
+def test_write_gitattributes_creates_file(tmp_path: Path):
+    gitattributes = write_gitattributes(tmp_path)
+    assert gitattributes.exists()
+    content = gitattributes.read_text()
+    assert GITATTRIBUTES_HEADER in content
+    for pattern in LFS_PATTERNS:
+        assert pattern in content
+    assert "filter=lfs" in content
+
+
+def test_write_gitattributes_appends_to_existing(tmp_path: Path):
+    existing = tmp_path / ".gitattributes"
+    existing.write_text("*.txt text\n")
+    gitattributes = write_gitattributes(tmp_path)
+    content = gitattributes.read_text()
+    assert "*.txt text" in content
+    assert GITATTRIBUTES_HEADER in content
+    assert "*.pdf filter=lfs" in content
+
+
+def test_write_pre_commit_hook_creates_executable(tmp_path: Path):
+    (tmp_path / ".git" / "hooks").mkdir(parents=True)
+    hook_path = write_pre_commit_hook(tmp_path)
+    assert hook_path.exists()
+    content = hook_path.read_text()
+    assert "#!/usr/bin/env python3" in content
+    assert "LFS pre-commit check" in content
+    st = hook_path.stat()
+    assert st.st_mode & stat.S_IXUSR
+    assert st.st_mode & stat.S_IXGRP
+    assert st.st_mode & stat.S_IXOTH
+
+
+def test_pre_commit_hook_accepts_small_files(tmp_path: Path):
+    (tmp_path / ".git" / "hooks").mkdir(parents=True)
+    write_pre_commit_hook(tmp_path)
+    hook_path = tmp_path / ".git" / "hooks" / "pre-commit"
+
+    import subprocess
+
+    result = subprocess.run(
+        ["python3", str(hook_path)],
+        capture_output=True,
+        text=True,
+        timeout=10,
+        cwd=str(tmp_path),
+    )
+    assert result.returncode == 0

--- a/tests/test_lfs.py
+++ b/tests/test_lfs.py
@@ -80,3 +80,44 @@ def test_pre_commit_hook_accepts_small_files(tmp_path: Path):
         cwd=str(tmp_path),
     )
     assert result.returncode == 0
+
+
+def test_pre_commit_hook_rejects_large_lfs_file(tmp_path: Path):
+    (tmp_path / ".git" / "hooks").mkdir(parents=True)
+    write_pre_commit_hook(tmp_path)
+    hook_path = tmp_path / ".git" / "hooks" / "pre-commit"
+
+    # Write .gitattributes with LFS pattern
+    (tmp_path / ".gitattributes").write_text("*.mp4 filter=lfs diff=lfs merge=lfs -text\n")
+
+    # Create a large .mp4 file and stage it
+    large_file = tmp_path / "video.mp4"
+    large_file.write_bytes(b"x" * (100 * 1024 + 1))
+
+    import subprocess
+    subprocess.run(["git", "init"], cwd=str(tmp_path), capture_output=True)
+    subprocess.run(["git", "add", str(large_file)], cwd=str(tmp_path), capture_output=True)
+
+    result = subprocess.run(
+        ["python3", str(hook_path)],
+        capture_output=True,
+        text=True,
+        timeout=10,
+        cwd=str(tmp_path),
+    )
+    assert result.returncode == 1
+    assert "not tracked by Git LFS" in result.stdout
+
+
+def test_write_gitattributes_idempotent(tmp_path: Path):
+    first = write_gitattributes(tmp_path)
+    first_content = first.read_text()
+    second = write_gitattributes(tmp_path)
+    second_content = second.read_text()
+    assert first_content == second_content
+
+
+def test_lfs_patterns_all_valid():
+    import re
+    for pattern in LFS_PATTERNS:
+        assert re.match(r"^\*\.[a-z0-9]+$", pattern), f"Invalid pattern: {pattern}"

--- a/tests/test_normalizer_media.py
+++ b/tests/test_normalizer_media.py
@@ -382,7 +382,9 @@ def test_frame_extraction_enabled_no_subtitles(
 
     assert "Text from frames" in content
     assert meta.get("transcript_source") == "ocr"
-    mock_download.assert_called_once()
+    assert mock_download.call_count == 2
+    assert "_video_path" in meta
+    assert "_video_tmpdir" in meta
     mock_extract.assert_called_once()
     mock_ocr.assert_called_once()
 

--- a/tests/test_normalizer_media.py
+++ b/tests/test_normalizer_media.py
@@ -343,7 +343,7 @@ def test_frame_extraction_fallback_opt_in(
             "description": "Short",  # Too short for caption fallback
         },
     )
-    mock_download.return_value = None  # Video download not attempted
+    mock_download.return_value = (None, None)  # Video download not attempted
 
     # Without frame extraction enabled
     normalizer.normalize("https://www.youtube.com/watch?v=frames", {})

--- a/uv.lock
+++ b/uv.lock
@@ -1937,6 +1937,7 @@ dependencies = [
     { name = "pyyaml" },
     { name = "tqdm" },
     { name = "trafilatura" },
+    { name = "yt-dlp" },
 ]
 
 [package.optional-dependencies]
@@ -1945,7 +1946,6 @@ all = [
     { name = "mcp" },
     { name = "pymupdf" },
     { name = "pymupdf4llm" },
-    { name = "yt-dlp" },
 ]
 dev = [
     { name = "pytest" },
@@ -1960,7 +1960,6 @@ mcp = [
 ]
 media = [
     { name = "faster-whisper" },
-    { name = "yt-dlp" },
 ]
 
 [package.dev-dependencies]
@@ -1987,7 +1986,7 @@ requires-dist = [
     { name = "research-keeper", extras = ["media", "documents", "mcp"], marker = "extra == 'all'" },
     { name = "tqdm", specifier = ">=4.67.3" },
     { name = "trafilatura", specifier = ">=2.0" },
-    { name = "yt-dlp", marker = "extra == 'media'" },
+    { name = "yt-dlp" },
 ]
 provides-extras = ["media", "documents", "mcp", "all", "dev"]
 


### PR DESCRIPTION
Closes #48

## Changes

- **Video download**: `rk add` now downloads video files for YouTube/Instagram URLs by default (opt-out with `--no-video` or config `video.enabled: false`)
- **yt-dlp to core**: No more `media` extra — yt-dlp is always available
- **LFS at init**: `rk init` installs git-lfs, writes `.gitattributes` for all binary types, and commits it
- **Pre-commit hook**: Python hook blocks large non-LFS-tracked binaries as a safety net
- **Doctor check**: `rk doctor` detects missing LFS config and offers to fix it
- **VideoConfig**: New config section with `enabled: true` default

## Design

Opt-out by default. No size cap. LFS is set up at init time so the repo stays lean. If LFS install fails, the pre-commit hook catches large binaries. See `docs/musings/video-artifact-management.md` for the full design rationale.